### PR TITLE
Add pagination to auditor list, simplify sidebar/nav, rebrand header

### DIFF
--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -12,10 +12,19 @@ export function DataTable({
   data,
   columns,
   showNavigation = false,
+  simpleNavigation = false,
   showSearch = false,
+  manualPagination = false,
+  pageCount,
+  pagination: controlledPagination,
+  onPaginationChange,
 }) {
   const [sorting, setSorting] = useState([]);
   const [globalFilter, setGlobalFilter] = useState('');
+  const [internalPagination, setInternalPagination] = useState({ pageIndex: 0, pageSize: 10 });
+
+  const pagination = manualPagination ? controlledPagination : internalPagination;
+  const setPagination = manualPagination ? onPaginationChange : setInternalPagination;
 
   const table = useReactTable({
     data,
@@ -23,13 +32,17 @@ export function DataTable({
     state: {
       sorting,
       globalFilter,
+      pagination,
     },
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    manualPagination,
+    ...(manualPagination ? { pageCount } : {}),
   });
 
   return (
@@ -104,13 +117,15 @@ export function DataTable({
       {showNavigation && (
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <button
-              className="px-3 py-1 text-sm bg-gray-100 rounded-lg disabled:opacity-50"
-              onClick={() => table.setPageIndex(0)}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
+            {!simpleNavigation && (
+              <button
+                className="px-3 py-1 text-sm bg-gray-100 rounded-lg disabled:opacity-50"
+                onClick={() => table.setPageIndex(0)}
+                disabled={!table.getCanPreviousPage()}
+              >
+                {'<<'}
+              </button>
+            )}
             <button
               className="px-3 py-1 text-sm bg-gray-100 rounded-lg disabled:opacity-50"
               onClick={() => table.previousPage()}
@@ -125,28 +140,34 @@ export function DataTable({
             >
               {'>'}
             </button>
-            <button
-              className="px-3 py-1 text-sm bg-gray-100 rounded-lg disabled:opacity-50"
-              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
+            {!simpleNavigation && (
+              <button
+                className="px-3 py-1 text-sm bg-gray-100 rounded-lg disabled:opacity-50"
+                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+                disabled={!table.getCanNextPage() || table.getPageCount() === -1}
+              >
+                {'>>'}
+              </button>
+            )}
           </div>
-          <span className="text-sm text-gray-700">
-            Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
-          </span>
-          <select
-            className="px-3 py-1 text-sm border rounded-lg"
-            value={table.getState().pagination.pageSize}
-            onChange={(e) => table.setPageSize(Number(e.target.value))}
-          >
-            {[5, 10, 20, 30, 40, 50].map((pageSize) => (
-              <option key={pageSize} value={pageSize}>
-                Show {pageSize}
-              </option>
-            ))}
-          </select>
+          {!simpleNavigation && (
+            <>
+              <span className="text-sm text-gray-700">
+                Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+              </span>
+              <select
+                className="px-3 py-1 text-sm border rounded-lg"
+                value={table.getState().pagination.pageSize}
+                onChange={(e) => table.setPageSize(Number(e.target.value))}
+              >
+                {[5, 10, 20, 30, 40, 50].map((pageSize) => (
+                  <option key={pageSize} value={pageSize}>
+                    Show {pageSize}
+                  </option>
+                ))}
+              </select>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -8,7 +8,6 @@ function Header() {
     const location = useLocation();
     const navigate = useNavigate();
     const { logout } = useAuth();
-    const auditor_name=localStorage.getItem("auditor_name")
 
     const handleLogout = () => {
         logout();
@@ -20,7 +19,7 @@ function Header() {
         switch (location.pathname) {
             case '/':
                 // return 'Home';
-                return 'Auditor Dashboard';
+                return 'Admin Dashboard';
             case '/auditors':
                 return 'Auditors';
             case '/customer':
@@ -46,11 +45,11 @@ function Header() {
 
                 <div className="flex items-center space-x-2">
                     <img
-                        src={`https://ui-avatars.com/api/?name=${auditor_name}`}
+                        src={`https://ui-avatars.com/api/?name=Super Admin`}
                         alt="Profile"
                         className="w-8 h-8 rounded-full"
                     />
-                    <span className="label-small">{auditor_name}</span>
+                    <span className="label-small">Super Admin</span>
                 </div>
                 <button onClick={handleLogout}>
                   <Power  className='text-red-500' />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,5 +1,5 @@
 import { NavLink, useLocation, useParams } from "react-router-dom";
-import { FaHome, FaCog, FaUserFriends, FaRegFileAlt, FaInfoCircle, FaUsers } from "react-icons/fa";
+import { FaHome, FaUserFriends, FaRegFileAlt, FaUsers } from "react-icons/fa";
 import homeIcon from "../assets/HomeHome.svg";
 import { Building2, FileText } from "lucide-react";
 function Sidebar() {
@@ -75,7 +75,7 @@ function Sidebar() {
                     <span>Auditor</span>
                 </NavLink>
 
-        <NavLink
+        {/* <NavLink
           to="/customer"
           className={({ isActive }) =>
             `flex items-center px-4 py-2 text-[#525866] label-small ${
@@ -96,34 +96,8 @@ function Sidebar() {
         >
           <FaRegFileAlt className="w-5 h-5 mr-3" />
           <span>Documents</span>
-        </NavLink>
+        </NavLink> */}
 
-        <div className="py-2 mt-4">
-          <p className="text-xs font-semibold text-gray-600 uppercase">Other</p>
-        </div>
-
-        <NavLink
-          to="/settings"
-          className={({ isActive }) =>
-            `flex items-center px-4 py-2 text-[#525866] label-small ${
-              isActive ? "bg-[#368FFD] text-[#ffff] rounded-lg" : ""
-            }`
-          }
-        >
-          <FaCog className="w-5 h-5 mr-3" />
-          <span>Settings</span>
-        </NavLink>
-        <NavLink
-          to="/help"
-          className={({ isActive }) =>
-            `flex items-center px-4 py-2 text-[#525866] label-small ${
-              isActive ? "bg-[#368FFD] text-[#ffff] rounded-lg" : ""
-            }`
-          }
-        >
-          <FaInfoCircle className="w-5 h-5 mr-3" />
-          <span>Help</span>
-        </NavLink>
       </nav>
     </div>
   );

--- a/src/components/auditors/AuditorTab.jsx
+++ b/src/components/auditors/AuditorTab.jsx
@@ -17,11 +17,15 @@ import { fetchAuditor } from "../../api/auditor";
 export function AuditorTab() {
   const navigate = useNavigate();
   const columnHelper = createColumnHelper();
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
   const {
     data: auditors,
     error,
     isLoading,
-  } = useCustomQuery("auditors", fetchAuditor);
+  } = useCustomQuery("auditors", fetchAuditor, {
+    page: pagination.pageIndex + 1,
+    pageSize: pagination.pageSize,
+  });
   const [selectedCard, setSelectedCard] = useState(null);
 
   const statuses = [
@@ -139,7 +143,7 @@ export function AuditorTab() {
           </button>
         </div>
      
-          <div className="flex overflow-x-auto whitespace-nowrap pb-4 gap-4">
+          <div className="flex flex-wrap pb-4 gap-4">
             {auditors?.map((auditor) => (
               <div
                 key={auditor.name}
@@ -154,7 +158,34 @@ export function AuditorTab() {
               </div>
             ))}
           </div>
-       
+
+          <div className="flex items-center justify-end gap-2 mt-2">
+            <button
+              className="px-3 py-1 text-sm bg-gray-100 rounded-lg disabled:opacity-50"
+              onClick={() =>
+                setPagination((prev) => ({
+                  ...prev,
+                  pageIndex: Math.max(0, prev.pageIndex - 1),
+                }))
+              }
+              disabled={pagination.pageIndex === 0}
+            >
+              {'<'}
+            </button>
+            <button
+              className="px-3 py-1 text-sm bg-gray-100 rounded-lg disabled:opacity-50"
+              onClick={() =>
+                setPagination((prev) => ({
+                  ...prev,
+                  pageIndex: prev.pageIndex + 1,
+                }))
+              }
+              disabled={!auditors || auditors.length < pagination.pageSize}
+            >
+              {'>'}
+            </button>
+          </div>
+
       </div>
 
       {/* Profile Section */}

--- a/src/components/auditors/CustomerTable.jsx
+++ b/src/components/auditors/CustomerTable.jsx
@@ -14,6 +14,8 @@ export function CustomerTable({customers,columns}) {
       <DataTable
         data={customers}
         columns={columns}
+        showNavigation={true}
+        simpleNavigation={true}
       />
     </div>
   );

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -13,7 +13,8 @@ export const API_CONFIG = {
 
     AUDITORS: {
       BASE: 'auditor',
-      LOGIN:"auditor/login"
+      LOGIN:"login"
+
       
     },
     CUSTOMER: {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -85,10 +85,16 @@ function Home() {
 
 
 
+   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+
    const { data, error, isLoading } = useCustomQuery(
        "auditors",
-       fetchAuditor
+       fetchAuditor,
+       { page: pagination.pageIndex + 1, pageSize: pagination.pageSize }
      );
+
+  const auditors = data ?? [];
+  const pageCount = -1; // total page count unknown; server returns one page per request
 
   console.log(data);
   
@@ -243,8 +249,14 @@ function Home() {
               <hr className='my-4' />
 
               <DataTable
-                data={data || []}
+                data={auditors}
                 columns={columns}
+                showNavigation={true}
+                simpleNavigation={true}
+                manualPagination={true}
+                pageCount={pageCount}
+                pagination={pagination}
+                onPaginationChange={setPagination}
               />
             </div>
             <PerformanceTable />


### PR DESCRIPTION
- Add server-side page/pageSize pagination to Dashboard and Auditor tab lists
- Add simpleNavigation mode to DataTable for prev/next-only controls
- Remove Settings/Help menu items and comment out Customer/Documents from sidebar
- Update login endpoint path
- Rename header title to Admin Dashboard and show Super Admin in navbar